### PR TITLE
Fixing width of c-scholworks__ancillary and c-scholworks__thumbnail

### DIFF
--- a/app/jsx/components/ScholWorksComp.jsx
+++ b/app/jsx/components/ScholWorksComp.jsx
@@ -22,19 +22,19 @@ class ScholWorksComp extends React.Component {
           </ul>
           <heading>
             <h2 className="c-scholworks__heading">
-              <a href="">From the New Heights: The City and Migrating Latinas in Real Woman Have Curves and Maria Full of Grace</a>
+              <a href="">{faker.fake("{{lorem.sentence}}")}</a>
             </h2 >
           </heading>
           <AuthorListComp />
           <div className="c-scholworks__publication">
-            <a href="">Mester Journal, Volume 42, Issue 1</a> (2012)
+            <a href="">{faker.fake("{{commerce.department}}")} Journal, Volume 42, Issue 1</a> (2012)
           </div>
           <div className="c-scholworks__abstract">
-            <p>{faker.fake("{{lorem.paragraphs}}")}</p>
+            <p>{faker.fake("{{lorem.words}}")}</p>
           </div>
-          <div className="c-scholworks__media">
-            <MediaListComp />
-          </div>
+          {/*  <div className="c-scholworks__media">
+            <MediaListComp />   
+          </div>  */}
         </div>
         <div className="c-scholworks__ancillary">
           <a className="c-scholworks__thumbnail" href="">

--- a/app/jsx/components/ScholWorksComp.jsx
+++ b/app/jsx/components/ScholWorksComp.jsx
@@ -30,11 +30,11 @@ class ScholWorksComp extends React.Component {
             <a href="">{faker.fake("{{commerce.department}}")} Journal, Volume 42, Issue 1</a> (2012)
           </div>
           <div className="c-scholworks__abstract">
-            <p>{faker.fake("{{lorem.words}}")}</p>
+            <p>{faker.fake("{{lorem.paragraph}}")}</p>
           </div>
-          {/*  <div className="c-scholworks__media">
+          <div className="c-scholworks__media">
             <MediaListComp />   
-          </div>  */}
+          </div>
         </div>
         <div className="c-scholworks__ancillary">
           <a className="c-scholworks__thumbnail" href="">

--- a/app/jsx/components/TabMetricsComp.jsx
+++ b/app/jsx/components/TabMetricsComp.jsx
@@ -10,28 +10,30 @@ class TabMetricsComp extends React.Component {
         <h1 className="c-tabcontent__main-heading" tabIndex="-1">Metrics</h1>
         <div className="c-tabcontent__divide2x">
           <div className="c-tabcontent__divide2x-child">
-            <table className="c-datatable">
-              <caption>Total Usage</caption>
-              <thead>
-                <tr>
-                  <th scope="col">Actions</th>
-                  <th scope="col">Total</th>
-                  <th scope="col">Monthly Average</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th scope="row">Hits</th>
-                  <td>Odio</td>
-                  <td>Lorem</td>
-                </tr>
-                <tr>
-                  <th scope="row">Downloads</th>
-                  <td>Iusto</td>
-                  <td>Architecto</td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="c-datatable">
+              <table>
+                <caption>Total Usage</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Actions</th>
+                    <th scope="col">Total</th>
+                    <th scope="col">Monthly Average</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Hits</th>
+                    <td>Odio</td>
+                    <td>Lorem</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Downloads</th>
+                    <td>Iusto</td>
+                    <td>Architecto</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
             <h2 className="o-heading3">By Month</h2>
             <div className="c-itemactions">
               <div className="o-input__droplist2">
@@ -51,32 +53,34 @@ class TabMetricsComp extends React.Component {
                 </select>
               </div>
             </div>
-            <table className="c-datatable">
-              <thead>
-                <tr>
-                  <th scope="col">Monthly</th>
-                  <th scope="col">Hits</th>
-                  <th scope="col">Downloads</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th scope="row">2016-03</th>
-                  <td>1,268</td>
-                  <td>271</td>
-                </tr>
-                <tr>
-                  <th scope="row">2016-02</th>
-                  <td>1,269</td>
-                  <td>250</td>
-                </tr>
-                <tr>
-                  <th scope="row">2016-01</th>
-                  <td>1,110</td>
-                  <td>233</td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="c-datatable">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Monthly</th>
+                    <th scope="col">Hits</th>
+                    <th scope="col">Downloads</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">2016-03</th>
+                    <td>1,268</td>
+                    <td>271</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">2016-02</th>
+                    <td>1,269</td>
+                    <td>250</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">2016-01</th>
+                    <td>1,110</td>
+                    <td>233</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
           <div className="c-tabcontent__divide2x-child">
             <img src={MEDIA_PATH + 'sample_data.png'} alt="sample data"/>

--- a/app/scss/_scholworks.scss
+++ b/app/scss/_scholworks.scss
@@ -120,6 +120,7 @@ $scholworks-tag-height: 1.4em;
 .c-scholworks__ancillary {
   flex: 0 0 auto;
   align-self: flex-start;
+  width: 9.4em;
 }
 
 .c-scholworks__thumbnail {
@@ -136,7 +137,7 @@ $scholworks-tag-height: 1.4em;
 
   img {
     display: block;
-    width: 8em;
+    width: 128px;
     height: auto;
   }
 

--- a/app/scss/_scholworks.scss
+++ b/app/scss/_scholworks.scss
@@ -118,7 +118,7 @@ $scholworks-tag-height: 1.4em;
 }
 
 .c-scholworks__ancillary {
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   align-self: flex-start;
 }
 


### PR DESCRIPTION
When width wasn't fixed, thumbnail was temporarily stretching out as it was being scrolled onto screen.

I also corrected HTML for data table represented in TabMetricsComp