### PR TITLE
Issue Caption reveal (dotdotdot)

### DIFF
--- a/app/jsx/components/IssueComp.jsx
+++ b/app/jsx/components/IssueComp.jsx
@@ -15,10 +15,8 @@ class IssueComp extends React.Component {
    setTimeout(()=> $(this.element).trigger('update'), 0) // removes 'more' link upon page load if less than truncation threshold
   }
   destroydotdotdot = event => {
-    // debugger;
-    $(this.element).removeClass("c-issue__caption-truncate")
     $(this.element).trigger('destroy')
-
+    $(this.element).removeClass("c-issue__caption-truncate")
   }
   render() {
     return (
@@ -29,12 +27,13 @@ class IssueComp extends React.Component {
             src="https://escholarship.org/images/homecover_fb.png"
             alt="journal cover" />
           <figcaption className="c-issue__caption-truncate" ref={e => this.element = e}>
-          <i>Cover Caption:</i> The cover image is from {faker.fake("{{lorem.paragraph}}")} <button className="c-issue__caption-truncate-more">More</button>
+            <div><i>Cover Caption:</i> The cover image is from {faker.fake("{{lorem.paragraph}}")} <button className="c-issue__caption-truncate-more">More</button></div>
           </figcaption>
         </figure>
         <div className="c-issue__description">
           <p>{faker.fake("{{lorem.paragraph}}")}</p>
-          <p>{faker.fake("{{lorem.paragraph}}")}</p>
+          {/* <p>{faker.fake("{{lorem.paragraph}}")}</p>
+          <p>{faker.fake("{{lorem.paragraph}} {{lorem.paragraph}}")}</p> */}
         </div>
       </div>
     )

--- a/app/jsx/components/IssueComp.jsx
+++ b/app/jsx/components/IssueComp.jsx
@@ -3,8 +3,23 @@
 import React from 'react'
 import LazyImageComp from '../components/LazyImageComp.jsx'
 import faker from 'faker/locale/en'
+import $ from 'jquery'
 
 class IssueComp extends React.Component {
+  componentDidMount() {    
+   $(this.element).dotdotdot({
+     watch: 'window',
+     after: '.c-issue__caption-truncate-more',
+     callback: ()=> $(this.element).find(".c-issue__caption-truncate-more").click(this.destroydotdotdot)
+  });
+   setTimeout(()=> $(this.element).trigger('update'), 0) // removes 'more' link upon page load if less than truncation threshold
+  }
+  destroydotdotdot = event => {
+    // debugger;
+    $(this.element).removeClass("c-issue__caption-truncate")
+    $(this.element).trigger('destroy')
+
+  }
   render() {
     return (
       <div className="c-issue">
@@ -13,11 +28,13 @@ class IssueComp extends React.Component {
           <LazyImageComp
             src="https://escholarship.org/images/homecover_fb.png"
             alt="journal cover" />
-          <figcaption><i>Cover Caption:</i> The cover image is from {faker.fake("{{lorem.paragraph}}")}.</figcaption>
+          <figcaption className="c-issue__caption-truncate" ref={e => this.element = e}>
+          <i>Cover Caption:</i> The cover image is from {faker.fake("{{lorem.paragraph}}")} <button className="c-issue__caption-truncate-more">More</button>
+          </figcaption>
         </figure>
         <div className="c-issue__description">
-          <p>{faker.fake("{{lorem.paragraph}}")}
-          </p>
+          <p>{faker.fake("{{lorem.paragraph}}")}</p>
+          <p>{faker.fake("{{lorem.paragraph}}")}</p>
         </div>
       </div>
     )

--- a/app/jsx/layouts/JournalSimpleLayout.jsx
+++ b/app/jsx/layouts/JournalSimpleLayout.jsx
@@ -10,6 +10,7 @@ import PubComp from '../components/PubComp.jsx'
 import JournalInfoComp from '../components/JournalInfoComp.jsx'
 import RelatedItemsComp from '../components/RelatedItemsComp.jsx'
 import FooterComp from '../components/FooterComp.jsx'
+import faker from 'faker/locale/en'
 import $ from 'jquery'
 
 // Load dotdotdot in browser but not server:
@@ -19,10 +20,7 @@ if (!(typeof document === "undefined")) {
 
 class JournalSimpleLayout extends React.Component {
 
-  componentDidMount() {
-    $('.c-pub__heading, .c-pub__abstract').dotdotdot({watch: 'window'
-    });
-    
+  componentDidMount() {    
     $(this.element).dotdotdot({
       watch: 'window',
       after: '.o-columnbox__truncate-more',
@@ -89,7 +87,8 @@ class JournalSimpleLayout extends React.Component {
             <h2>About</h2>
           </header>
           <div className="o-columnbox__truncate1" ref={element => this.element = element}>
-            <p>A Journal of Italian Studies Edited by the Graduate Students of the Department of Italian at UCLA  <button className="o-columnbox__truncate-more">More</button>
+            <p>A Journal of Italian Studies {faker.fake("{{lorem.paragraph}}")}</p>
+            <p>{faker.fake("{{lorem.paragraph}} {{lorem.paragraph}}")} <button className="o-columnbox__truncate-more">More</button>
             </p>
           </div>
         </section>

--- a/app/scss/_issue.scss
+++ b/app/scss/_issue.scss
@@ -55,7 +55,7 @@
   img {
     width: $thumbnail-width;
     height: auto;
-    margin-bottom: $spacing-base;
+    margin: 0 $spacing-base $spacing-base 0;
     border: 1px solid $color-light-gray;
     box-shadow: $box-shadow2;
 
@@ -73,7 +73,6 @@
       right: 0;
       bottom: 0;
       left: $thumbnail-width;
-      // margin-left: $spacing-md;
       font-size: 0.9em;
       grid-column: 2;
       grid-row: 3 / span 2;

--- a/app/scss/_issue.scss
+++ b/app/scss/_issue.scss
@@ -11,7 +11,7 @@
     @supports (display: contents) and (display: flow-root) {
       display: grid;
       grid-template-columns: auto 1fr;
-      grid-template-rows: auto 1fr auto;
+      grid-template-rows: auto 1fr auto auto;
     }
 
   }
@@ -23,7 +23,7 @@
     @include bp(screen1) {
       position: absolute;
       right: 0;
-      left: 0;
+      left: $thumbnail-width;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
@@ -61,25 +61,22 @@
 
     @include bp(screen1) {
       margin: 0 $spacing-md 0 0;
-      grid-row: 1 / 4;
+      grid-row: 1 / span 3;
     }
 
   }
 
   figcaption {
-    
+
     @include bp(screen1) {
       position: absolute;
       right: 0;
       bottom: 0;
       left: $thumbnail-width;
-      margin-left: $spacing-md;
+      // margin-left: $spacing-md;
       font-size: 0.9em;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
       grid-column: 2;
-      grid-row: 3;
+      grid-row: 3 / span 2;
 
       @supports (display: contents) and (display: flow-root) {
         left: 0;
@@ -104,6 +101,27 @@
       margin: 0;
     }
 
+  }
+
+}
+
+.c-issue__caption-truncate {
+
+  @include bp(screen1) {
+    max-height: 1.9em; // truncate to 1 line per jquery.dotdotdot
+    white-space: nowrap;
+    overflow: hidden;  // hide text beyond max-height
+  }
+
+}
+
+// Button to show untruncated text:
+.c-issue__caption-truncate-more {
+  @extend %o-button__7;
+  display: none;
+
+  @include bp(screen1) {
+    display: contents;
   }
 
 }


### PR DESCRIPTION
Corrections made in compliance with this pivotal ticket: https://www.pivotaltracker.com/story/show/152092429

But one legacy bug I have lost patience trying to fix: When description text gets bigger, opened caption text can overlap this segment.

There are currently no journal issues with caption thumbnail and large description text, so OK for now. But should probably fix this someday.