### PR TITLE
 Links under clientmarkup don't need u-one-line-truncation mixin

### DIFF
--- a/app/jsx/components/SubheaderComp.jsx
+++ b/app/jsx/components/SubheaderComp.jsx
@@ -1,7 +1,6 @@
 // ##### Subheader Component ##### //
 
 import React from 'react'
-import MEDIA_PATH from '../../js/MediaPath.js'
 
 class SubheaderComp extends React.Component {
   render() {
@@ -34,7 +33,7 @@ class SubheaderComp extends React.Component {
         </div>
         <a className="c-subheader__banner--wide" href="">
           <h1>Western Journal of Emergency Medicine</h1>
-          <img src={MEDIA_PATH + 'temp_journal-banner.png'} alt="Western Journal of Emergency Medicine"/>
+          <img src={this.props.banner} alt="Western Journal of Emergency Medicine"/>
         </a>
         <div className="c-subheader__sidebar">
           <button className="o-button__3">Submit</button>

--- a/app/jsx/components/SubheaderComp.jsx
+++ b/app/jsx/components/SubheaderComp.jsx
@@ -31,7 +31,7 @@ class SubheaderComp extends React.Component {
             </div>
           </details>
         </div>
-        <a className="c-subheader__banner--wide" href="">
+        <a className={this.props.wide ? "c-subheader__banner--wide" : "c-subheader__banner--narrow"} href="">
           <h1>Western Journal of Emergency Medicine</h1>
           <img src={this.props.banner} alt="Western Journal of Emergency Medicine"/>
         </a>

--- a/app/jsx/display/SubheaderDisp.jsx
+++ b/app/jsx/display/SubheaderDisp.jsx
@@ -8,15 +8,18 @@ class SubheaderDisp extends React.Component {
   render() {
     return (
       <div>
-        <h2>Ideal banner dimensions are 9.19 x 1 and no higher than 87 pixels. Otherwise, image gets stretched or becomes too narrow (in most browsers).</h2>
-        <h1>Banner = 675 x 75 pixels</h1>
-        <SubheaderComp banner={MEDIA_PATH + 'temp_journal-banner.png'} />
-        <h1>Banner = 600 x 200 pixels (stretched horizontally)</h1>
+        <h3>For wide setting, Ideal banner dimensions are 9.19 x 1 and no higher than 87 pixels. Otherwise, image gets stretched or becomes too narrow (in most browsers).</h3>
+        <hr />
+        <h2>Wide Setting: Logo image contains the full, legible title of your site. Banner = 675 x 75 pixels</h2>
+        <SubheaderComp banner={MEDIA_PATH + 'temp_journal-banner.png'} wide={true} />
+        <h2>Narrow Setting and Banner = 600 x 200 pixels</h2>
+        <SubheaderComp banner={"https://picsum.photos/600/200/?image=951"} wide={false} />
+        <h2>Wide Setting and Banner = 600 x 200 pixels (stretched horizontally)</h2>
         <img src="https://via.placeholder.com/600x200?text=UC+San+Diego+(600x200)"/>
-        <SubheaderComp banner="https://via.placeholder.com/600x200?text=UC+San+Diego+(600x200)" />
-        <h1>Banner = 1100 x 87 pixels (too narrow)</h1>
+        <SubheaderComp banner="https://via.placeholder.com/600x200?text=UC+San+Diego+(600x200)" wide={true} />
+        <h2>Wide Setting and Banner = 1100 x 87 pixels (too narrow)</h2>
         <img src="https://via.placeholder.com/1100x87?text=UC+San+Diego+(1100x87)"/>
-        <SubheaderComp banner="https://via.placeholder.com/1100x87?text=UC+San+Diego+(1100x87)" />
+        <SubheaderComp banner="https://via.placeholder.com/1100x87?text=UC+San+Diego+(1100x87)" wide={true} />
       </div>
     )
   }

--- a/app/jsx/display/SubheaderDisp.jsx
+++ b/app/jsx/display/SubheaderDisp.jsx
@@ -8,7 +8,7 @@ class SubheaderDisp extends React.Component {
   render() {
     return (
       <div>
-        <h3>For wide setting, Ideal banner dimensions are 9.19 x 1 and no higher than 87 pixels. Otherwise, image gets stretched or becomes too narrow (in most browsers).</h3>
+        <h3>For wide setting, Ideal banner dimensions are 9.19 x 1 and no higher than 87 pixels. NB: There is a restriction built into the CMS that should prevent images with incompatible dimensions from being submitted in the first place.</h3>
         <hr />
         <h2>Wide Setting: Logo image contains the full, legible title of your site. Banner = 675 x 75 pixels</h2>
         <SubheaderComp banner={MEDIA_PATH + 'temp_journal-banner.png'} wide={true} />

--- a/app/jsx/display/SubheaderDisp.jsx
+++ b/app/jsx/display/SubheaderDisp.jsx
@@ -2,12 +2,21 @@
 
 import React from 'react'
 import SubheaderComp from '../components/SubheaderComp.jsx'
+import MEDIA_PATH from '../../js/MediaPath.js'
 
 class SubheaderDisp extends React.Component {
   render() {
     return (
       <div>
-        <SubheaderComp />
+        <h2>Ideal banner dimensions are 9.19 x 1 and no higher than 87 pixels. Otherwise, image gets stretched or becomes too narrow (in most browsers).</h2>
+        <h1>Banner = 675 x 75 pixels</h1>
+        <SubheaderComp banner={MEDIA_PATH + 'temp_journal-banner.png'} />
+        <h1>Banner = 600 x 200 pixels (stretched horizontally)</h1>
+        <img src="https://via.placeholder.com/600x200?text=UC+San+Diego+(600x200)"/>
+        <SubheaderComp banner="https://via.placeholder.com/600x200?text=UC+San+Diego+(600x200)" />
+        <h1>Banner = 1100 x 87 pixels (too narrow)</h1>
+        <img src="https://via.placeholder.com/1100x87?text=UC+San+Diego+(1100x87)"/>
+        <SubheaderComp banner="https://via.placeholder.com/1100x87?text=UC+San+Diego+(1100x87)" />
       </div>
     )
   }

--- a/app/scss/_clientmarkup.scss
+++ b/app/scss/_clientmarkup.scss
@@ -27,14 +27,10 @@
   // ***** Links ***** //
 
   a {
-    // ToDo: This is similar to c-pubinfo__link...
-    //  It might make sense to create an object with this wrapping property,
-    //  but maybe something to change once we have a regession testing suite.
+    // Similar to c-pubinfo__link, but without the u-one-line-truncation mixin
     @extend %o-textlink__secondary;
-    @include u-one-line-truncation(active);
 
     @include bp(screen1) {
-      @include u-one-line-truncation(inactive);
       @include u-overflow-wrap();
     }
   }


### PR DESCRIPTION
And added subheader banner dimension rules, but sort of moot since there is a restriction built into the CMS that should prevent images with incompatible dimensions from being submitted in the first place