### PR TITLE
Items in 'magazine layout' should not break across columns

### DIFF
--- a/app/jsx/layouts/JournalSplashyLayout.jsx
+++ b/app/jsx/layouts/JournalSplashyLayout.jsx
@@ -74,7 +74,21 @@ class JournalSplashyLayout extends React.Component {
               <ItemActionsComp />
               <CustomSelectorObj />
               <IssueComp />
-              <h3 className="o-heading1a">Table of Contents</h3>
+              <h3 className="o-heading1a">Introduction</h3>
+              <div className="o-dividecontent2x--ruled">
+                <div className="c-pub">
+                  <h4 className="c-pub__heading"><a href="">Italy in the Mediterranean Today: A New Critical Topography</a></h4>
+                  <div className="c-authorlist">
+                    <ul className="c-authorlist__list">
+                      <li><a href="">Fogu, Claudio</a></li>
+                      <li><a href="">Re, Lucia</a></li>
+                      <li><a href="" className="c-authorlist__list-more-link">et al.</a></li>
+                    </ul>
+                  </div>
+                  <div className="c-pub__abstract"><div className="c-clientmarkup"><p>Editors' Introduction to Volume 1, Issue 1.</p></div></div>
+                </div>
+              </div>
+              <h3 className="o-heading1a">A Critical Map of Italy in the Mediterranean - Defining the terms</h3>
               <div className="o-dividecontent2x--ruled">
                 <PubComp />
                 <img src="http://placehold.it/300x150?text=Image" alt="" />

--- a/app/jsx/objects/DivideContentObj.jsx
+++ b/app/jsx/objects/DivideContentObj.jsx
@@ -1,6 +1,7 @@
 // ##### Divide Content Objects ##### //
 
 import React from 'react'
+import PubComp from '../components/PubComp.jsx'
 import faker from 'faker/locale/en'
 
 class DivideContentObj extends React.Component {
@@ -14,12 +15,27 @@ class DivideContentObj extends React.Component {
           <p>{faker.fake("{{lorem.paragraphs}}")}</p>
           <p>{faker.fake("{{lorem.paragraphs}}")}</p>
         </div>
-        <h1>Divide Content into 2 Balanced Columns with Rule</h1>
+        <h1>Divide Content into 2 Balanced Columns with Rule - Short</h1>
         <div className="o-dividecontent2x--ruled">
-          <p>{faker.fake("{{lorem.paragraphs}}")}</p>
-          <p>{faker.fake("{{lorem.paragraphs}}")}</p>
-          <p>{faker.fake("{{lorem.paragraphs}}")}</p>
-          <img src="http://placehold.it/250x150?text=Image" alt="" />
+          <div className="c-pub">
+            <h4 className="c-pub__heading"><a href="">Italy in the Mediterranean Today: A New Critical Topography</a></h4>
+            <div className="c-authorlist">
+              <ul className="c-authorlist__list">
+                <li><a href="">Fogu, Claudio</a></li>
+                <li><a href="">Re, Lucia</a></li>
+                <li><a href="" className="c-authorlist__list-more-link">et al.</a></li>
+              </ul>
+            </div>
+            <div className="c-pub__abstract"><div className="c-clientmarkup"><p>Editors' Introduction to Volume 1, Issue 1.</p></div></div>
+          </div>
+        </div>
+        <h1>Divide Content into 2 Balanced Columns with Rule - Lengthy</h1>
+        <div className="o-dividecontent2x--ruled">
+          <PubComp />
+          <img src="http://placehold.it/350x150?text=Image" alt="" />
+          <PubComp />
+          <img src="http://placehold.it/300x150?text=Image" alt="" />
+          <PubComp />
         </div>
       </div>
     )

--- a/app/scss/_pub.scss
+++ b/app/scss/_pub.scss
@@ -2,6 +2,7 @@
 
 .c-pub {
   display: inline-block;
+  width: 100%;
   margin-bottom: $spacing-md;
   break-inside: avoid;
 }

--- a/app/scss/_pub.scss
+++ b/app/scss/_pub.scss
@@ -1,6 +1,7 @@
 // ##### Publication Component ##### //
 
 .c-pub {
+  display: inline-block;
   margin-bottom: $spacing-md;
   break-inside: avoid;
 }

--- a/app/scss/_withdrawmodal.scss
+++ b/app/scss/_withdrawmodal.scss
@@ -9,7 +9,8 @@
   font-weight: 700;
 }
 
-.c-withdrawmodal__publicMessage, .c-withdrawmodal__internalComment {
+.c-withdrawmodal__publicMessage, 
+.c-withdrawmodal__internalComment {
   display: block;
   width: 600px;
   margin-bottom: 10px;


### PR DESCRIPTION
Adding 
`display: inline-block;`
and
`width: 100%;`
to PubComp's css fixed the problem