### PR TITLE
On mobile view, refine drawer must slide out over search results.

### DIFF
--- a/app/scss/_refine.scss
+++ b/app/scss/_refine.scss
@@ -13,6 +13,7 @@
 
   [class^='c-refine__drawer'] {
     position: absolute;
+    z-index: 1;
   }
 
 }


### PR DESCRIPTION
…he refine controls are visible and usable.