### PR TITLE
Remove u-overflow-wrap mixin from links in clientmarkup

### DIFF
--- a/app/jsx/components/JournalInfoComp.jsx
+++ b/app/jsx/components/JournalInfoComp.jsx
@@ -13,6 +13,8 @@ class JournalInfoComp extends React.Component {
           <li><b>e-ISSN-</b> 0160-2764</li>
           <li><b>e-ISSN-</b> 0160-2765</li>
         </ul>
+        <p><a href=''>ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ</a>
+        </p>
       </div>
     )
   }

--- a/app/scss/_clientmarkup.scss
+++ b/app/scss/_clientmarkup.scss
@@ -30,9 +30,7 @@
     // Similar to c-pubinfo__link, but without the u-one-line-truncation mixin
     @extend %o-textlink__secondary;
 
-    @include bp(screen1) {
-      @include u-overflow-wrap();
-    }
+    @include bp(screen1)
   }
 
   // ***** Lists ***** //

--- a/app/scss/_journalinfo.scss
+++ b/app/scss/_journalinfo.scss
@@ -15,4 +15,8 @@
 
   }
 
+  a {
+    @include u-overflow-wrap();
+  }
+
 }


### PR DESCRIPTION
RE: Pivotal-Tracker story 1320348, remove the u-overflow-wrap mixin from
the link SCSS in clientmarkup.scss.